### PR TITLE
Strict decode

### DIFF
--- a/src/GHC/Prof.hs
+++ b/src/GHC/Prof.hs
@@ -1,5 +1,6 @@
 module GHC.Prof
   ( decode
+  , decode'
 
   -- * Parser
   , profile
@@ -29,7 +30,9 @@ module GHC.Prof
   ) where
 
 import qualified Data.Attoparsec.Text.Lazy as ATL
+import qualified Data.Attoparsec.Text as ATS
 import qualified Data.Text.Lazy as TL
+import qualified Data.Text as TS
 
 import GHC.Prof.CostCentreTree
 import GHC.Prof.Parser (profile)
@@ -40,3 +43,7 @@ decode :: TL.Text -> Either String Profile
 decode text = case ATL.parse profile text of
   ATL.Fail _unconsumed _contexts reason -> Left reason
   ATL.Done _unconsumed prof -> Right prof
+
+-- | Decode a GHC time allocation profiling report from a strict 'ATS.Text'
+decode' :: TS.Text -> Either String Profile
+decode' text = ATS.parseOnly (profile <* ATS.endOfInput) text

--- a/tests/Regression.hs
+++ b/tests/Regression.hs
@@ -18,6 +18,7 @@ import Test.Tasty.HUnit
 import qualified Data.Attoparsec.Text.Lazy as ATL
 import qualified Data.Set as Set
 import qualified Data.Text.Lazy.IO as TL
+import qualified Data.Text.IO as TS
 
 import GHC.Prof
 
@@ -33,6 +34,11 @@ main = withSystemTempDirectory "test" $ \dir -> withCurrentDirectory dir $
     for_ profiles $ \prof -> do
       step $ "Parsing " ++ prof
       assertProfile prof
+    for_ profiles $ \prof -> do
+      step $ "Decode  " ++ prof
+      assertDecode prof
+      step $ "Decode' " ++ prof
+      assertDecode' prof
 
 generateProfiles :: IO [FilePath]
 generateProfiles = do
@@ -57,17 +63,35 @@ profilingFlags =
   , ("full", "-pa")
   ]
 
+caseStudy :: Profile -> IO ()
+caseStudy prof = do
+  let actual = Set.fromList $ map Similar $ aggregatedCostCentres prof
+      expected = Set.fromList $ map Similar $ profileTopCostCentres prof
+  assertBool
+    ("Missing cost centre(s): " ++ show (Set.difference expected actual)) $
+      Set.isSubsetOf expected actual
+
+
 assertProfile :: FilePath -> Assertion
 assertProfile path = do
   text <- TL.readFile path
   case ATL.parse profile text of
-    ATL.Done _ prof -> do
-      let actual = Set.fromList $ map Similar $ aggregatedCostCentres prof
-          expected = Set.fromList $ map Similar $ profileTopCostCentres prof
-      assertBool
-        ("Missing cost centre(s): " ++ show (Set.difference expected actual)) $
-          Set.isSubsetOf expected actual
+    ATL.Done _ prof -> caseStudy prof
     ATL.Fail _ _ reason -> assertFailure reason
+
+assertDecode :: FilePath -> Assertion
+assertDecode path = do
+  text <- TL.readFile path
+  case decode text of
+    Right prof -> caseStudy prof
+    Left reason -> assertFailure reason
+
+assertDecode' :: FilePath -> Assertion
+assertDecode' path = do
+  text <- TS.readFile path
+  case decode' text of
+    Right prof -> caseStudy prof
+    Left reason -> assertFailure reason
 
 newtype Similar = Similar AggregatedCostCentre
 


### PR DESCRIPTION
* This should solve #11.
* There are now tests for both `decode` and `decode'` that are analogous to the previously existing test for `parse`.

Additionally, there is a change to previously existing test code that I saw fit to make: the scrutiny of a parse result is abstracted from the specific test cases, to a function named `caseStudy`. I was careful not to interfere with the logic. This abstraction makes sure all the tests interpret their parse result in the same way.