### PR TITLE
Allow building with GHC 9.2.2

### DIFF
--- a/ghc-prof.cabal
+++ b/ghc-prof.cabal
@@ -37,6 +37,7 @@ tested-with: GHC == 7.6.3
   || == 8.10.3
   || == 8.10.4
   || == 9.0.1
+  || == 9.2.2
 
 flag dump
   description: Build the executable "dump"
@@ -51,7 +52,7 @@ library
   other-modules:
     Control.Monad.Extras
   build-depends:
-      base >= 4.6 && < 4.16
+      base >= 4.6 && < 4.17
     , attoparsec < 0.15
     , containers >= 0.5 && < 0.7
     , scientific < 0.4


### PR DESCRIPTION
`cabal v2-test` passes.